### PR TITLE
Support for defining content objects inline

### DIFF
--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -314,7 +314,12 @@ module.exports = function( grunt ) {
 
 			checkFile( src );
 
-			var values = options.content ? grunt.file.readJSON( options.content ) : {};
+			var values;
+			if ( typeof options.content === "string" ) {
+				values = grunt.file.readJSON( options.content );
+			} else {
+				values = options.content ? options.content : {};
+			}
 
 			if ( options.section ) {
 


### PR DESCRIPTION
Prevents having to create a separate file when only setting a single content variable.
