### PR TITLE
Fixed validation of inline attribute "false"

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,11 @@ Determines the base directory for includes that are specified with an absolute p
 
 `<!--(bake /includes/footer.html)-->` relative to the basePath (level of Gruntfile by default)
 
+#### options.semanticIf
+Type: `Bool` | `Array` | `Function`
+Default value: false
 
+Set to `true` enables support for _no_/_yes_ and _off_/_on_ in `_if` statements. Alternatively false values can be defined via Array or a callback can be used for evaluation.
 
 ### Usage Examples
 

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -103,6 +103,14 @@ module.exports = function( grunt ) {
 			return values;
 		}
 
+		// Helper method to check if a value represents false
+
+		function isFalse( value ) {
+			var untrues = ["false", "no"];
+			var string = String(value).toLowerCase();
+
+			return ( value === undefined || value === false || untrues.indexOf( string ) !== -1 );
+		}
 
 		// Helper method to resolve nested placeholder names like: "home.footer.text"
 
@@ -125,7 +133,7 @@ module.exports = function( grunt ) {
 			}
 
 			var current = mout.object.get( values, name );
-			var returnValue = current === false || current === undefined ? false : true;
+			var returnValue = !isFalse(current);
 
 			return invert ? ! returnValue : returnValue;
 		}

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -23,6 +23,7 @@ module.exports = function( grunt ) {
 		var options = this.options( {
 			content: null,
 			section: null,
+			semanticIf: false,
 			basePath: "",
 			parsePattern: /\{\{\s*([\.\-\w]*)\s*\}\}/g
 		} );
@@ -106,10 +107,25 @@ module.exports = function( grunt ) {
 		// Helper method to check if a value represents false
 
 		function isFalse( value ) {
-			var untrues = ["false", "no"];
 			var string = String(value).toLowerCase();
 
-			return ( value === undefined || value === false || untrues.indexOf( string ) !== -1 );
+			if( value === undefined || value === false || string === 'false' ) {
+				return true;
+			}
+
+			if( options.semanticIf === true ) {
+				return mout.array.indexOf(['no', 'off'], string) !== -1;
+			}
+
+			if( mout.lang.isArray( options.semanticIf ) ) {
+				return mout.array.indexOf(options.semanticIf, string) !== -1;
+			}
+
+			if( mout.lang.isFunction( options.semanticIf ) ) {
+				return options.semanticIf(value);
+			}
+
+			return false;
 		}
 
 		// Helper method to resolve nested placeholder names like: "home.footer.text"


### PR DESCRIPTION
I noticed, that inline assignments of `"false"` dit not work because they are given as strings and then strict compared to `false`.

__Example__
In file `index.html`
```
<!--(bake partial.tpl.html showHeader="false")-->
```
In file `partial.tpl.html`
```
<!--(bake-start _if="showHeader")-->
    <h1>Hello World!</h1>	
<!--(bake-end)-->
<p>This is text.</p>
```
__Expected result__
```
<p>This is text.</p>
```
__Current Result__
```
<h1>Hello World!</h1>	
<p>This is text.</p>
```

### Addition: Semantic if
We often use partials with some `_if` statements for things like "project properties". I thought that other may do so as well and integrated an option to enable "semantic" statements using `"off"`or `"no"`. It is disabled by default.

```
<!--(bake partial.tpl.html 
    usesCSS="yes"
    usesJS="yes"
    usesPHP="no")-->
```
I added a description for this option to the README. The new code passed all your tests.