### PR TITLE
Added callback support for options.content

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ The paths given are relative to the file being parsed.
 ### Options
 
 #### options.content
-Type: `String` or `Object`
+Type: `String` or `Object` or `Function`
 Default value: `null`
 
-A string value that determines the location of the JSON file that is used to fill the place holders. If a `Object` is specified it will be used as content.
+A string value that determines the location of the JSON file that is used to fill the place holders. If a `Object` is specified it will be used as content. If a `Function` is specified its return (should be JSON) will be used as content.
 
 #### options.section
 Type: `String`

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -394,6 +394,8 @@ module.exports = function( grunt ) {
 			var values;
 			if ( mout.lang.isString( options.content ) ) {
 				values = grunt.file.readJSON( options.content );
+			} else if( mout.lang.isFunction( options.content ) ) {
+				values = options.content();
 			} else {
 				values = options.content ? options.content : {};
 			}


### PR DESCRIPTION
This PR addes option for manipulating (or generating) the content JSON in the Gruntfile by supporting callback function for `options.content`. 

Example: We have JSON with data about rooms

```JSON
{
    "rooms": [
        {
            "width": "9",
            "depth": "5",
            "height": "2"
        },
        {
            "width": "4",
            "depth": "2",
            "height": "2.4"
        }
    ]
}
```

And we want to add the volume. We can now compute these on the fly:

``` Javascript
options: {
    content: function() {
        var data = grunt.file.readJSON('data/content.json');

        data.rooms = _.map(data.rooms, function(room) {
            room.volume = room.width * room.depth * room.height;

            return room;
        });

        return data;
    }
}
```

And use this in the template

```HTML
<table>
    <!--(bake-start _foreach="room:rooms")-->
        <tr>
            <td>W: {{room.width}}</td>
            <td>D: {{room.depth}}</td>
            <td>H: {{room.height}}</td>
            <td>V: {{room.volume}}</td>
        </tr>
    <!--(bake-end)-->
</table>
```