### PR TITLE
ads simple operator validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
+sudo: false
 node_js:
-  - "0.10"
+  - "0.11"
+  - "0.12"
+  - "4.0"
 before_script:
   - npm install -g grunt-cli

--- a/README.md
+++ b/README.md
@@ -285,13 +285,23 @@ This bake task will create _app/index.html_:
 
 The __bake__ task also allows a simple `if` conditional. Inline attributes named `_if` are treated as such. If the value that `_if` holds can't be found in the content.json or if found equals to the value `false` the include will be ignored. The `_if` can also be used inverted to create a `_else` effect in a way. A definition as `_if="!name"` would mean the template will be rendered when `name` cannot be found or is `false`.
 
+Alternativly, `_if` suppoerts two operators. the `==` and the `=!` operator. This allows to specify the name of the value and the content in single quotes, if the content is a string.
+__Note: This is a simple implementation of the equals operator and is based solely on strings.__
+
 _app/base.html_:
 ```html
 <html>
 	<body>
 		<!--(bake includes/container.html _if="name")-->
+
+		<!--(bake includes/other.html _if="foo == 'bar'")-->
 	</body>
 </html>
+```
+
+_includes/other.html_:
+```html
+<span>{{foo}}</span>
 ```
 
 _app/content.json_:
@@ -307,6 +317,7 @@ This bake task will create _app/index.html_:
 <html>
 	<body>
 
+		<span>bar</span>
 	</body>
 </html>
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "grunt-bake",
 	"description": "Bake external includes into files to create static pages with no server-side compilation time",
-	"version": "0.3.15",
+	"version": "0.3.16",
 	"homepage": "https://github.com/MathiasPaumgarten/grunt-bake",
 	"author": {
 		"name": "Mathias Paumgarten",

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -193,12 +193,39 @@ module.exports = function( grunt ) {
 		// Handle _if attributes in inline arguments
 
 		function validateIf( inlineValues, values ) {
+
 			if ( "_if" in inlineValues ) {
 
 				var value = inlineValues[ "_if" ];
 				delete inlineValues[ "_if" ];
 
+				var operator = getOperator( value );
+
+				if ( operator ) {
+					var parts = value.split( operator );
+
+					var left = mout.string.rtrim( parts[ 0 ] );
+					var right = mout.string.ltrim( parts[ 1 ] ).replace( /'/g, "" );
+
+					var contentValue = resolveName( left, values );
+
+					if ( operator === "==" && contentValue === right ) return false;
+					else if ( operator === "!=" && contentValue !== right ) return false;
+
+					return true;
+				}
+
 				if ( ! hasValue( value, values ) ) return true;
+			}
+
+			return false;
+		}
+
+		function getOperator( string ) {
+			var operators = [ "==", "!=" ];
+
+			for ( var i = 0; i < operators.length; i++ ) {
+				if ( string.indexOf( operators[ i ] ) > -1 ) return operators[ i ];
 			}
 
 			return false;

--- a/test/expected/if_bake.html
+++ b/test/expected/if_bake.html
@@ -8,5 +8,9 @@
 		<div>Here is some content</div>
 
 		Include Two
+
+		<h1>Apple Pie</h1>
+
+		Include Two
 	</body>
 </html>

--- a/test/fixtures/if_bake.html
+++ b/test/fixtures/if_bake.html
@@ -12,5 +12,12 @@
 		<!--(bake-end)-->
 
 		<!--(bake includes/include-two.html _if="!bar")-->
+
+		<!--(bake-start _if="title == 'Apple Pie'")-->
+		<h1>{{title}}</h1>
+		<!--(bake-end)-->
+
+		<!--(bake includes/include-two.html _if="title != 'Orange Pie'")-->
+		<!--(bake includes/include-one.html _if="title == 'Orange Pie'")-->
 	</body>
 </html>


### PR DESCRIPTION
As proposed by @musdy I've added simple `==` and `!=` operators to the `_if` flag. Those operators work on strings exclusively so far. 

```html
<!--(bake includes/other.html _if="foo=='bar'")-->
```