### PR TITLE
Validates empty strings as false

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "grunt-bake",
 	"description": "Bake external includes into files to create static pages with no server-side compilation time",
-	"version": "0.3.16",
+	"version": "0.3.17",
 	"homepage": "https://github.com/MathiasPaumgarten/grunt-bake",
 	"author": {
 		"name": "Mathias Paumgarten",

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -109,7 +109,7 @@ module.exports = function( grunt ) {
 		function isFalse( value ) {
 			var string = String( value ).toLowerCase();
 
-			if ( value === undefined || value === false || string === "false" ) {
+			if ( value === "" || value === undefined || value === false || string === "false" ) {
 				return true;
 			}
 
@@ -215,7 +215,22 @@ module.exports = function( grunt ) {
 					return true;
 				}
 
-				if ( ! hasValue( value, values ) ) return true;
+				if ( ! hasValue( value, values ) ) {
+
+					return true;
+
+				} else if ( value[ 0 ] === "!" ) {
+
+					var name = value.substr( 1 );
+
+					return ! isFalse( resolveName( name, values ) );
+
+				} else if ( isFalse( resolveName( value, values ) ) ) {
+
+					return true;
+
+				}
+
 			}
 
 			return false;


### PR DESCRIPTION
@david-zacharias pointed out in #50 that empty strings in `_if` clauses get interpreted as `true`. This is fixed now.