### PR TITLE
Support for native if-condition parsing. Including tests for semanticIf.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -168,6 +168,16 @@ module.exports = function(grunt) {
 				}
 			},
 
+			semantic_if: {
+				options: {
+					semanticIf: true
+				},
+
+				files: {
+					"tmp/semantic_if.html": "test/fixtures/semantic_if.html"
+				}
+			},
+
 			format_bake: {
 				files: {
 					"tmp/format_bake.html": "test/fixtures/format_bake.html"

--- a/test/bake_test.js
+++ b/test/bake_test.js
@@ -17,6 +17,7 @@ exports.bake = {
 			"tmp/absolute_path_bake.html": "test/expected/default_bake.html",
 			"tmp/default_absolute_path_bake.html": "test/expected/default_bake.html",
 			"tmp/if_bake.html": "test/expected/if_bake.html",
+			"tmp/semantic_if.html": "test/expected/semantic_if.html",
 			"tmp/format_bake.html": "test/expected/format_bake.html",
 			"tmp/foreach_bake.html": "test/expected/foreach_bake.html" ,
 			"tmp/foreach-inline_bake.html": "test/expected/foreach-inline_bake.html",

--- a/test/expected/if_bake.html
+++ b/test/expected/if_bake.html
@@ -12,5 +12,13 @@
 		<h1>Apple Pie</h1>
 
 		Include Two
+
+		Include Two
+
+		Index 0:check
+		Index 1:
+		Index 2:check
+		Index 3:
+		Index 4:check
 	</body>
 </html>

--- a/test/expected/semantic_if.html
+++ b/test/expected/semantic_if.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+	<head></head>
+	<body>
+		<dt>
+
+			<dt>NodeJS</dt>
+			<dd>This project uses NodeJS.</dd>
+
+		</dt>
+	</body>
+</html>

--- a/test/fixtures/if_bake.html
+++ b/test/fixtures/if_bake.html
@@ -19,5 +19,14 @@
 
 		<!--(bake includes/include-two.html _if="title != 'Orange Pie'")-->
 		<!--(bake includes/include-one.html _if="title == 'Orange Pie'")-->
+
+		<!--(bake includes/include-one.html _if="'Apple Pie' == title && bar")-->
+		<!--(bake includes/include-two.html _if="'Apple Pie' == title && !bar")-->
+
+		Index 0: <!--(bake-start _if="0%2 === 0")-->check<!--(bake-end)-->
+		Index 1: <!--(bake-start _if="1%2 === 0")-->check<!--(bake-end)-->
+		Index 2: <!--(bake-start _if="2%2 === 0")-->check<!--(bake-end)-->
+		Index 3: <!--(bake-start _if="3%2 === 0")-->check<!--(bake-end)-->
+		Index 4: <!--(bake-start _if="4%2 === 0")-->check<!--(bake-end)-->
 	</body>
 </html>

--- a/test/fixtures/includes/project.html
+++ b/test/fixtures/includes/project.html
@@ -1,0 +1,16 @@
+<dt>
+	<!--(bake-start _if="usesPHP")-->
+	<dt>PHP</dt>
+	<dd>This project uses PHP.</dd>
+	<!--(bake-end)-->
+
+	<!--(bake-start _if="usesNodeJS")-->
+	<dt>NodeJS</dt>
+	<dd>This project uses NodeJS.</dd>
+	<!--(bake-end)-->
+
+	<!--(bake-start _if="usesASP")-->
+	<dt>ASP</dt>
+	<dd>This project uses ASP.</dd>
+	<!--(bake-end)-->
+</dt>

--- a/test/fixtures/semantic_if.html
+++ b/test/fixtures/semantic_if.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+	<head></head>
+	<body>
+		<!--(bake includes/project.html
+    		usesPHP="no"
+    		usesNodeJS="yes"
+    		usesASP="off")-->
+	</body>
+</html>


### PR DESCRIPTION
Here comes the PR for #69. I have added support for **semanticIf** and tests for this, since these have  been missing before.

To mute the warning from jshint regarding the *eval()* I tried `/*jshint -W061 */`, but *grunt-contrib-jshint*s version is to old. I think it's in general an good thing to update the dependencies. I can do this with help of `npm check` if that's okay for your, @MathiasPaumgarten.