### PR TITLE
Support for transforms with parameters.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -323,6 +323,40 @@ module.exports = function(grunt) {
 				}
 			},
 
+			transform_params: {
+				options: {
+					content: {
+						content: {
+							"string": "Bake",
+							"array": [
+								"Jim",
+								"John",
+								"James",
+								"Jonathan"
+							]
+						}
+					},
+					transforms: {
+						repeat: function( string, times ) {
+							return String( string ).repeat( times );
+						},
+						replace: function( string, searchvalue, newvalue ) {
+							return String( string ).replace( searchvalue, newvalue );
+						},
+						max: function( array, limit ) {
+							return array.slice( 0, limit );
+						},
+						join: function( array, glue ) {
+							return array.join( glue );
+						}
+					}
+				},
+
+				files: {
+					"tmp/transform_params.html": "test/fixtures/transform_params.html"
+				}
+			},
+
 			transform_multiple: {
 				options: {
 					content: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -398,6 +398,22 @@ module.exports = function(grunt) {
 				}
 			},
 
+			transform_foreach: {
+				options: {
+					content: "test/fixtures/content.json",
+					section: "en",
+					transforms: {
+						max: function( array, limit ) {
+							return ( array || [] ).slice( 0, limit );
+						}
+					}
+				},
+
+				files: {
+					"tmp/transform_foreach.html": "test/fixtures/transform_foreach.html"
+				}
+			},
+
 			keep_undefined_vars: {
 				options: {
 					content: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -338,7 +338,7 @@ module.exports = function(grunt) {
 					},
 					transforms: {
 						repeat: function( string, times ) {
-							return String( string ).repeat( times );
+							return new Array( parseInt( times, 10) + 1 ).join( String( string ) );
 						},
 						replace: function( string, searchvalue, newvalue ) {
 							return String( string ).replace( searchvalue, newvalue );

--- a/README.md
+++ b/README.md
@@ -166,12 +166,16 @@ transforms: {
 }
 ```
 
-#### options.transformGutter
-Type: `String`
-Default value: '|'
+Transforms support parameters like `{{myvar | replace:'A':'B'}}`. Parameters are handed into the callback as additional parameters.
 
-Sequence used to split transforms.
-
+```js
+transforms: {
+    // str => content of myvar,  searchvalue => 'A',  newvalue => 'B'
+    replace: function(str, searchvalue, newvalue) {
+        return String(str).replace(searchvalue, newvalue);
+    }
+}
+```
 
 #### options.semanticIf
 Type: `Bool` | `Array` | `Function`

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -55,42 +55,51 @@ module.exports = function( grunt ) {
 		// This process method is used when no process function is supplied.
 		function defaultProcess( template, content ) {
 			return template.replace( options.parsePattern, function( match, inner ) {
+				var processed = processPlaceholder( inner, content );
 
-				// extract transforms from placeholder
-				var transforms = inner.match( transformsRegex ).map( function( str ) {
-
-					// remove whitespace, otherwise transforms and variable key may not be found
-					str = mout.string.trim( str );
-
-					// extract name of transform and transform parameters, and clear quotes
-					var parts = str.match( paramsRegex ).map( function( str ) {
-						return mout.string.trim( str, "'" );
-					});
-
-					return {
-						name: parts[0],
-						params: parts.slice(1)
-					};
-				});
-
-				// the first value is the set that contains our variable key, and not a transfrom
-				var key = transforms.shift().name;
-				var resolved = resolveName( key, content );
-
-				if( resolved === undefined && !options.removeUndefined ) {
+				if( processed === undefined && !options.removeUndefined ) {
 					return match;
 				}
 
-				return transforms.reduce( applyTransform, resolved );
-			} );
+				return processed;
+			});
 		}
 
 		if ( ! options.hasOwnProperty( "process" ) ) {
 			options.process = defaultProcess;
 		}
 
+		function processPlaceholder( placeholder, values ) {
+			// extract transforms from placeholder
+			var transforms = placeholder.match( transformsRegex ).map( function( str ) {
+
+				// remove whitespace, otherwise transforms and variable key may not be found
+				str = mout.string.trim( str );
+
+				// extract name of transform and transform parameters, and clear quotes
+				var parts = str.match( paramsRegex ).map( function( str ) {
+					return mout.string.trim( str, "'" );
+				});
+
+				return {
+					name: parts[0],
+					params: parts.slice(1)
+				};
+			});
+
+			// the first value is the set that contains our variable key, and not a transfrom
+			var key = transforms.shift().name;
+			var resolved = resolveName( key, values );
+
+			return transforms.reduce( applyTransform, resolved );
+		}
+
 		function applyTransform( content, transform ) {
 			var name = transform.name;
+
+			if( content === undefined ) {
+				return;
+			}
 
 			// check if transform is registred
 			if( ! mout.object.has( options.transforms, name ) ) {

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -252,7 +252,7 @@ module.exports = function( grunt ) {
 				return string.match( arrayRegex )[ 1 ].split( "," );
 
 			else {
-				var array = resolveName( string, values );
+				var array = processPlaceholder( string, values );
 				if ( ! mout.lang.isArray( array ) ) array = [];
 
 				return array;
@@ -343,14 +343,15 @@ module.exports = function( grunt ) {
 
 			if ( "_foreach" in inlineValues ) {
 
-				var pair = inlineValues[ "_foreach" ].split( ":" );
+				var set = inlineValues[ "_foreach" ].split( ":" );
 				delete inlineValues[ "_foreach" ];
 
-				getArrayValues( pair[ 1 ], values ).forEach( function( value ) {
+				// as transforms may contain colons, join rest of list to recreate original string
+				getArrayValues( set.slice(1).join( ":" ), values ).forEach( function( value ) {
 					array.push( value );
 				} );
 
-				return pair[ 0 ];
+				return set[ 0 ];
 			}
 
 			return null;

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -31,12 +31,17 @@ module.exports = function( grunt ) {
 		} );
 
 
+		// warning about removed parameter
+
+		if ( options.transformGutter !== undefined ) {
+			grunt.log.error( "Parameter 'transformGutter' is no longer supported. See #71 for details." );
+		}
+
 		// normalize basePath
 
 		if ( options.basePath.substr( -1 , 1 ) !== "/" && options.basePath.length > 0 ) {
 			options.basePath = options.basePath + "/";
 		}
-
 
 		// normalize content
 

--- a/test/bake_test.js
+++ b/test/bake_test.js
@@ -32,6 +32,7 @@ exports.bake = {
 			"tmp/transform_params.html": "test/expected/transform_params.html",
 			"tmp/transform_multiple.html": "test/expected/transform_multiple.html",
 			"tmp/transform_deep.html": "test/expected/transform_deep.html",
+			"tmp/transform_foreach.html": "test/expected/transform_foreach.html",
 			"tmp/foreach_meta.html": "test/expected/foreach_meta.html",
 			"tmp/multiline_bake.html": "test/expected/multiline_bake.html",
 			"tmp/var_as_array_key.html": "test/expected/var_as_array_key.html",

--- a/test/bake_test.js
+++ b/test/bake_test.js
@@ -29,6 +29,7 @@ exports.bake = {
 			"tmp/function_content_bake.html": "test/expected/function_content_bake.html",
 			"tmp/transform_pass_through.html": "test/expected/transform_pass_through.html",
 			"tmp/transform_single.html": "test/expected/transform_single.html",
+			"tmp/transform_params.html": "test/expected/transform_params.html",
 			"tmp/transform_multiple.html": "test/expected/transform_multiple.html",
 			"tmp/transform_deep.html": "test/expected/transform_deep.html",
 			"tmp/foreach_meta.html": "test/expected/foreach_meta.html",

--- a/test/expected/transform_foreach.html
+++ b/test/expected/transform_foreach.html
@@ -1,0 +1,4 @@
+<ul>
+	<li>foo</li>
+	<li>bar</li>
+</ul>

--- a/test/expected/transform_params.html
+++ b/test/expected/transform_params.html
@@ -1,0 +1,3 @@
+<span>BakeBakeBakeBake</span>
+<span>Cake</span>
+<span>Jim | John</span>

--- a/test/fixtures/transform_foreach.html
+++ b/test/fixtures/transform_foreach.html
@@ -1,0 +1,3 @@
+<ul>
+	<!--(bake includes/li.html _foreach="value:items | max: 2")-->
+</ul>

--- a/test/fixtures/transform_params.html
+++ b/test/fixtures/transform_params.html
@@ -1,0 +1,3 @@
+<span>{{ content.string | repeat:4 }}</span>
+<span>{{ content.string | replace:'B':'C' }}</span>
+<span>{{ content.array | max:2 | join:' | ' }}</span>


### PR DESCRIPTION
Hi Mathias,

this is my last bigger extension for the next month, I promise :innocent: 

Had this already in mind when I wrote `options.transforms`, but had no time to think about the needed regular expressions for allowing parameters which may contain the enquoted delimiter. Today I came across a handy expression on [stackoverflow](http://stackoverflow.com/a/9610055/4166350) that did the trick so I quickly added this feature.

Since a simple `.split("|")` does not do work with enquoted delimiters, I have removed `options.transformGutter`. Because it was introduced recently I do not think that many people (or at least someone) used it to change the gutter. Anyway, if you prefer not to remove it *silently*, we can build the regex dynamically (personally I dislike this), or we can add a warning if someone using `options.transformGutter`? Also thought about making `transformsRegex` and `paramsRegex` configurable via `options.`, but they are quite specific for the use case so I am not sure if anyone wants to change it... also defaultProcess became pretty complex since base 0.3.x ... now you know my thoughts, maybe you have a good idea?
