### PR TITLE
Fix multi-file section content

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,6 +82,18 @@ module.exports = function(grunt) {
 				}
 			},
 
+			advanced_bake_multi: {
+				options: {
+					content: "test/fixtures/content.json",
+					section: "en"
+				},
+
+				files: {
+					"tmp/advanced_bake_multi_one.html": "test/fixtures/advanced_bake_multi_one.html",
+					"tmp/advanced_bake_multi_two.html": "test/fixtures/advanced_bake_multi_two.html"
+				}
+			},
+
 			object_bake: {
 				options: {
 					content: {

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -53,6 +53,15 @@ module.exports = function( grunt ) {
 			options.content = options.content ? options.content : {};
 		}
 
+		if ( options.section ) {
+
+			if ( ! options.content[ options.section ] ) {
+				grunt.log.error( "content doesn't have section " + options.section );
+			}
+
+			options.content = options.content[ options.section ];
+		}
+
 		// =======================
 		// -- DEFAULT PROCESSOR --
 		// =======================
@@ -591,15 +600,6 @@ module.exports = function( grunt ) {
 			var dest = file.dest;
 
 			if ( ! checkFile( src ) ) return;
-
-			if ( options.section ) {
-
-				if ( ! options.content[ options.section ] ) {
-					grunt.log.error( "content doesn't have section " + options.section );
-				}
-
-				options.content = options.content[ options.section ];
-			}
 
 			bakeFile( src, dest, options.content );
 		} );

--- a/test/bake_test.js
+++ b/test/bake_test.js
@@ -10,6 +10,8 @@ exports.bake = {
 		var files = {
 			"tmp/default_bake.html": "test/expected/default_bake.html",
 			"tmp/advanced_bake.html": "test/expected/advanced_bake.html",
+			"tmp/advanced_bake_multi_one.html": "test/expected/advanced_bake_multi_one.html",
+			"tmp/advanced_bake_multi_two.html": "test/expected/advanced_bake_multi_two.html",
 			"tmp/costum_process_bake.html": "test/expected/costum_process_bake.html",
 			"tmp/recursive_bake.html": "test/expected/recursive_bake.html",
 			"tmp/inline_recursive_bake.html": "test/expected/inline_recursive_bake.html",

--- a/test/expected/advanced_bake_multi_one.html
+++ b/test/expected/advanced_bake_multi_one.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+	<head></head>
+	<body>
+		Include One
+	</body>
+</html>

--- a/test/expected/advanced_bake_multi_two.html
+++ b/test/expected/advanced_bake_multi_two.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+	<head></head>
+	<body>
+		Include Two
+	</body>
+</html>

--- a/test/fixtures/advanced_bake_multi_one.html
+++ b/test/fixtures/advanced_bake_multi_one.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+	<head></head>
+	<body>
+		<!--(bake includes/include-one.html)-->
+	</body>
+</html>

--- a/test/fixtures/advanced_bake_multi_two.html
+++ b/test/fixtures/advanced_bake_multi_two.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+	<head></head>
+	<body>
+		<!--(bake includes/include-two.html)-->
+	</body>
+</html>


### PR DESCRIPTION
If you have multiple files, the content/section code no-longer works.

This is because each file in the iteration sets `options.content = options.content[option.section]`. Therefore on the second call you're essentially settings  `options.content = options.content[option.section][option.section]`, which is therefore undefined.

This PR should fix this bug.