### PR TITLE
allow _section to target object properties

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -249,6 +249,12 @@ module.exports = function(grunt) {
 						},
 						about: {
 							title: "About"
+						},
+						books: {
+							theDarkTower: {
+								author: "Stephen King",
+								title: "The Dark Tower"
+							}
 						}
 					}
 				},

--- a/test/expected/section_bake.html
+++ b/test/expected/section_bake.html
@@ -4,6 +4,7 @@
 	<body>
 		<span>About</span>
 		<span>Home</span>
+		<span>The Dark Tower</span>
 
 		<span>Home</span>
 	</body>

--- a/test/fixtures/section_bake.html
+++ b/test/fixtures/section_bake.html
@@ -4,6 +4,7 @@
 	<body>
 		<!--(bake includes/second.html _section="about")-->
 		<!--(bake includes/second.html _section="home")-->
+		<!--(bake includes/second.html _section="books.theDarkTower")-->
 
 		<!--(bake-start _section="home")-->
 		<span>{{title}}</span>


### PR DESCRIPTION
I expected this to already be working, since I can access object properties in an _if (`_if="book.title == 'The Dark Tower'"`), but it appears to not work on _section.

I've written a unit test so you can see what I expected to happen.