### PR TITLE
Added support for _assign-attribute.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -528,6 +528,12 @@ module.exports = function(grunt) {
 				files: {
 					"tmp/assign_bake.html": "test/fixtures/assign_bake.html"
 				}
+			},
+
+			inline_no_process: {
+				files: {
+					"tmp/inline_no_process.html": "test/fixtures/inline_no_process.html"
+				}
 			}
 		}
 	} );

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -522,6 +522,12 @@ module.exports = function(grunt) {
 				files: {
 					"tmp/extra_bake_multiple.html": "test/fixtures/extra_bake_multiple.html"
 				}
+			},
+
+			assign_bake: {
+				files: {
+					"tmp/assign_bake.html": "test/fixtures/assign_bake.html"
+				}
 			}
 		}
 	} );

--- a/README.md
+++ b/README.md
@@ -559,6 +559,38 @@ _dist/index.html_:
 </html>
 ```
 
+#### Inline _assign statement
+
+The `_assign` statement determines to save included content into a variable instead of placing it directly. The variables name is defined by `_assign`-value.
+
+_app/base.html_:
+```html
+<html>
+    <body>
+        <!--(bake includes/file.html _assign="foo")-->
+        {{foo}}
+        <p>{{foo}}</p>
+    </body>
+</html>
+```
+
+_app/includes/file.html_:
+```html
+<span>Hello World</span>
+```
+
+This will create:
+
+_dist/index.html_:
+```html
+<html>
+    <body>
+        <span>Hello World</span>
+        <p><span>Hello World</span></p>
+    </body>
+</html>
+```
+
 #### Bake extra pages (e.g. detail pages)
 
 Another special inline attribute is the `_bake` attribute. This keyword expects a specific syntax which allows to dynamically create additional files. It accepts the syntax: `_bake="template.html > target.html"`.

--- a/README.md
+++ b/README.md
@@ -591,6 +591,38 @@ _dist/index.html_:
 </html>
 ```
 
+
+#### Inline _process statement
+
+Set to `true` the `_process` statement prevents bake from processing the included files content. The include takes place, but neither placeholders become replaced nor further bake sections processed.
+
+_app/base.html_:
+```html
+<html>
+    <body>
+        <!--(bake includes/file.html _process="false")-->
+    </body>
+</html>
+```
+
+_app/includes/file.html_:
+```html
+<!--(bake includes/other.html)-->
+<span>{{foo}}</span>
+```
+
+This will create:
+
+_dist/index.html_:
+```html
+<html>
+    <body>
+        <!--(bake includes/other.html)-->
+		<span>{{foo}}</span>
+    </body>
+</html>
+```
+
 #### Bake extra pages (e.g. detail pages)
 
 Another special inline attribute is the `_bake` attribute. This keyword expects a specific syntax which allows to dynamically create additional files. It accepts the syntax: `_bake="template.html > target.html"`.

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -410,6 +410,20 @@ module.exports = function( grunt ) {
 			return null;
 		}
 
+		// Handle _process attributes in inline arguments
+
+		function validateProcess( inlineValues ) {
+			if ( "_process" in inlineValues ) {
+
+				var value = inlineValues[ "_process" ];
+				delete inlineValues[ "_process" ];
+
+				return String(value).toLowerCase() === 'true' ;
+			}
+
+			return true;
+		}
+
 		function preparePath( includePath, filePath, values ) {
 
 			// replace placeholders within the include path
@@ -455,6 +469,7 @@ module.exports = function( grunt ) {
 			var section = validateSection( inlineValues, values );
 			var extraBake = validateBake( inlineValues );
 			var assign = validateAssign( inlineValues );
+			var doProcess = validateProcess( inlineValues );
 
 			if ( section !== null ) {
 				values = mout.object.get( parentValues, section );
@@ -476,7 +491,10 @@ module.exports = function( grunt ) {
 
 			var content = ""; // result of current bake-section
 
-			if( forEachName && forEachValues.length > 0 ) {
+			if( !doProcess ) {
+				content = linebreak + includeContent;
+
+			} else if( forEachName && forEachValues.length > 0 ) {
 
 				var fragment = "";
 				var oldValue = values[ forEachName ];
@@ -516,7 +534,7 @@ module.exports = function( grunt ) {
 			if( assign !== null ) {
 				parentValues[ assign ] = mout.string.ltrim( content );
 
-				return "";
+				content = "";
 			}
 
 			return content;

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -396,6 +396,20 @@ module.exports = function( grunt ) {
 			return null;
 		}
 
+		// Handle _assign attributes in inline arguments
+
+		function validateAssign( inlineValues ) {
+			if ( "_assign" in inlineValues ) {
+
+				var value = inlineValues[ "_assign" ];
+				delete inlineValues[ "_assign" ];
+
+				return value;
+			}
+
+			return null;
+		}
+
 		function preparePath( includePath, filePath, values ) {
 
 			// replace placeholders within the include path
@@ -435,13 +449,15 @@ module.exports = function( grunt ) {
 			return replaceString( includeContent, linebreak, indent, includePath, attributes, filePath, destFile, values );
 		}
 
-		function replaceString( includeContent, linebreak, indent, includePath, attributes, filePath, destFile, values ) {
+		function replaceString( includeContent, linebreak, indent, includePath, attributes, filePath, destFile, parentValues ) {
+			var values = parentValues;
 			var inlineValues = parseInlineValues( attributes );
 			var section = validateSection( inlineValues, values );
 			var extraBake = validateBake( inlineValues );
+			var assign = validateAssign( inlineValues );
 
 			if ( section !== null ) {
-				values = mout.object.get( values, section );
+				values = mout.object.get( parentValues, section );
 			}
 
 			// resolve placeholders within inline values so these can be used in subsequent grunt-tags (see #67)
@@ -451,13 +467,14 @@ module.exports = function( grunt ) {
 
 			if ( validateIf( inlineValues, values ) ) return "";
 			if ( validateRender( inlineValues ) ) return "";
-
 			var forEachValues = [];
 			var forEachName = validateForEach( inlineValues, values, forEachValues );
 
 			values = mout.object.merge( values, inlineValues );
 
 			includeContent = applyIndent( indent, includeContent);
+
+			var content = ""; // result of current bake-section
 
 			if( forEachName && forEachValues.length > 0 ) {
 
@@ -483,18 +500,26 @@ module.exports = function( grunt ) {
 				if ( oldValue === undefined ) values[ forEachName ] = oldValue;
 				else delete values[ forEachName ];
 
-				return fragment;
+				content = fragment;
 
 			} else if( !forEachName ) {
 
 				processExtraBake( extraBake, filePath, destFile, values );
 
-				return linebreak + parse( includeContent, includePath, destFile, values );
+				content = linebreak + parse( includeContent, includePath, destFile, values );
 
 			} else {
 
+				content = "";
+			}
+
+			if( assign !== null ) {
+				parentValues[ assign ] = mout.string.ltrim( content );
+
 				return "";
 			}
+
+			return content;
 		}
 
 		// =====================

--- a/test/bake_test.js
+++ b/test/bake_test.js
@@ -45,7 +45,8 @@ exports.bake = {
 			"tmp/extra_bake_multiple.html": "test/expected/extra_bake_multiple.html",
 			"tmp/extra-page.html": "test/expected/extra/extra-page.html",
 			"tmp/extra-0-a-team.html": "test/expected/extra/extra-0-a-team.html",
-			"tmp/extra-1-b-team.html": "test/expected/extra/extra-1-b-team.html"
+			"tmp/extra-1-b-team.html": "test/expected/extra/extra-1-b-team.html",
+			"tmp/assign_bake.html": "test/expected/assign_bake.html"
 		};
 
 		test.expect( mout.object.size( files ) );

--- a/test/bake_test.js
+++ b/test/bake_test.js
@@ -46,7 +46,8 @@ exports.bake = {
 			"tmp/extra-page.html": "test/expected/extra/extra-page.html",
 			"tmp/extra-0-a-team.html": "test/expected/extra/extra-0-a-team.html",
 			"tmp/extra-1-b-team.html": "test/expected/extra/extra-1-b-team.html",
-			"tmp/assign_bake.html": "test/expected/assign_bake.html"
+			"tmp/assign_bake.html": "test/expected/assign_bake.html",
+			"tmp/inline_no_process.html": "test/expected/inline_no_process.html"
 		};
 
 		test.expect( mout.object.size( files ) );

--- a/test/expected/assign_bake.html
+++ b/test/expected/assign_bake.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+	<head></head>
+	<body>
+
+		<p>
+			<span>Hello World!</span>
+		</p>
+	</body>
+</html>

--- a/test/expected/inline_no_process.html
+++ b/test/expected/inline_no_process.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+	<head></head>
+	<body>
+		<div><!--(bake second.html)--></div>
+
+		<div><span>Hello World</span></div>
+	</body>
+</html>

--- a/test/fixtures/assign_bake.html
+++ b/test/fixtures/assign_bake.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+	<head></head>
+	<body>
+		<!--(bake includes/second.html title="Hello World!" _assign="foo")-->
+
+		<p>
+			{{foo}}
+		</p>
+	</body>
+</html>

--- a/test/fixtures/inline_no_process.html
+++ b/test/fixtures/inline_no_process.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+	<head></head>
+	<body>
+		<!--(bake includes/first.html _process="false" title="Hello World")-->
+
+		<!--(bake includes/first.html _process="true" title="Hello World")-->
+	</body>
+</html>


### PR DESCRIPTION
Hi @MathiasPaumgarten, here is another small addition to `grunt-bake`. It allows to assign the contents of an include to a variable / placeholder instead of placing it directly. I came up with the idea to solve issues like from @k-funk in #81 in a clean way. With `_assign` it's now possible to apply custom transforms (like an escape transform) to included content. Also a included content could be placed multiple times at different places within the parent document.

_app/base.html_:
```html
<html>
    <body>
        <!--(bake includes/example.html _assign="code")-->
        {{code}}
        <pre>{{code | escape}}</pre>
    </body>
</html>
```

_app/includes/example.html_:
```html
<p>Some code</p>
```

_Bake configuration_:
```js
build: {
  options: {
    transforms: {
      escape: function( string ) {
        return String( string )
          .replace(/&/g, "&amp;")
          .replace(/</g, "&lt;")
          .replace(/>/g, "&gt;")
          .replace(/"/g, "&quot;")
          .replace(/'/g, "&#039;");
      }
    }
  },
  files: {
    "app/index.html": "app/base.html"
  }
}
```

This bake task will create _app/index.html_:
```html
<html>
    <body>
        <p>Some code</p>
        <pre>&lt;p&gt;Some code&lt;/p&gt;</pre>
    </body>
</html>
```