### PR TITLE
Fix: Placeholders still become replaced when _process set to false.

### DIFF
--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -512,7 +512,7 @@ module.exports = function( grunt ) {
 
 					processExtraBake( extraBake, filePath, destFile, values );
 
-					fragment += linebreak + parse( includeContent, includePath, destFile, values );
+					fragment += linebreak + processContent( parse( includeContent, includePath, destFile, values ), values );
 				} );
 
 				if ( oldValue === undefined ) values[ forEachName ] = oldValue;
@@ -524,7 +524,7 @@ module.exports = function( grunt ) {
 
 				processExtraBake( extraBake, filePath, destFile, values );
 
-				content = linebreak + parse( includeContent, includePath, destFile, values );
+				content = linebreak + processContent( parse( includeContent, includePath, destFile, values ), values );
 
 			} else {
 
@@ -602,7 +602,7 @@ module.exports = function( grunt ) {
 			var section = extractSection( fileContent );
 
 			if( section ) {
-				fileContent = section.before;
+				fileContent = processContent( section.before, values );
 
 				if( section.inner ) {
 					fileContent += replaceString( section.inner, "", "", filePath, section.attributes, filePath, destFile, values );
@@ -612,9 +612,12 @@ module.exports = function( grunt ) {
 				}
 
 				fileContent += parse( section.after, filePath, destFile, values );
+
+			} else {
+				return processContent( fileContent, values );
 			}
 
-			return processContent( fileContent, values );
+			return fileContent;
 		}
 
 		// Run process function if processor-function is defined

--- a/test/expected/inline_no_process.html
+++ b/test/expected/inline_no_process.html
@@ -5,5 +5,9 @@
 		<div><!--(bake second.html)--></div>
 
 		<div><span>Hello World</span></div>
+
+		<span>{{  title  }}</span>
+
+		<span>Hello World</span>
 	</body>
 </html>

--- a/test/fixtures/inline_no_process.html
+++ b/test/fixtures/inline_no_process.html
@@ -5,5 +5,9 @@
 		<!--(bake includes/first.html _process="false" title="Hello World")-->
 
 		<!--(bake includes/first.html _process="true" title="Hello World")-->
+
+		<!--(bake includes/second.html _process="false" title="Hello World")-->
+
+		<!--(bake includes/second.html _process="true" title="Hello World")-->
 	</body>
 </html>


### PR DESCRIPTION
This is a hotfix including tests for bug reported in issue #81  