### PR TITLE
Permanent default variables

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,6 +12,5 @@
 	"node": true,
 	"quotmark": "double",
 	"unused": true,
-	"noarg": true,
 	"trailing": true
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -534,6 +534,12 @@ module.exports = function(grunt) {
 				files: {
 					"tmp/inline_no_process.html": "test/fixtures/inline_no_process.html"
 				}
+			},
+
+			default_variables: {
+				files: {
+					"tmp/default_variables.html": "test/fixtures/default_variables.html"
+				}
 			}
 		}
 	} );
@@ -546,7 +552,23 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks( "grunt-contrib-watch" );
 	grunt.loadNpmTasks( "grunt-jsonlint" );
 
-	grunt.registerTask( "test", [ "clean", "bake", "nodeunit" ] );
+	grunt.registerTask( "test", [ "clean", "setup", "bake", "nodeunit", "teardown" ] );
 	grunt.registerTask( "default", [ "jsonlint", "jshint", "test" ] );
 
+
+	// Stubbing methods for testing purposes. Because we are good little developers
+	// we clean up after ourselves.
+	var realDateNow;
+
+	grunt.registerTask( "setup", function() {
+		realDateNow = Date.now;
+
+		Date.now = function() {
+			return 123456789;
+		};
+	} );
+
+	grunt.registerTask( "teardown", function() {
+		Date.now = realDateNow;
+	} );
 };

--- a/README.md
+++ b/README.md
@@ -79,6 +79,28 @@ Default value: `null`
 
 A string value that determines the location of the JSON file that is used to fill the place holders. If a `Object` is specified it will be used as content. If a `Function` is specified its return (should be JSON) will be used as content.
 
+Additionally to the content provided, __bake__ comes with a set of default values that are attached to a `__bake` object which gets injected to the user content.
+
+```js
+__bake.filename // the file path tbeing baked
+__bake.srcFilename // same as __bake.filename
+__bake.destFilename // the file path it is being written to
+__bake.timestamp // a timestamp (milliseconds) at baking
+```
+
+These can be especially usefull in combnation with [transforms](#optionstransforms).
+
+```html
+<html>
+    <head></head>
+    <body>
+        <!--(bake-start)-->
+        {{__bake.destFilename}} was written at {{__base.timestamp | parseDate }}
+        <!--(bake-end)-->
+    </body>
+</html>
+```
+
 #### options.section
 Type: `String`
 Default value: `""`

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -312,6 +312,7 @@ module.exports = function( grunt ) {
 
 				try {
 					/* jshint evil:true */
+					/* eslint-disable no-eval */
 
 					return ! eval( condition );
 
@@ -476,11 +477,7 @@ module.exports = function( grunt ) {
 			// resolve placeholders within inline values so these can be used in subsequent grunt-tags (see #67)
 			inlineValues = mout.object.map( inlineValues, function( value ) {
 				return processContent( value, values );
-			});
-
-			// inject system variables
-			inlineValues.__filename = filePath;
-			inlineValues.__timestamp = Date.now();
+			} );
 
 			if ( validateIf( inlineValues, values ) ) return "";
 			if ( validateRender( inlineValues ) ) return "";
@@ -501,6 +498,7 @@ module.exports = function( grunt ) {
 				var fragment = "";
 				var oldValue = values[ forEachName ];
 				var total = forEachValues.length;
+
 
 				forEachValues.forEach( function( value, index ) {
 					values[ forEachName ] = value;
@@ -579,8 +577,8 @@ module.exports = function( grunt ) {
 
 				remain = remain.slice( result.index + length );
 
-				depth += (result[ 3 ] === "-start");
-				depth -= (result[ 3 ] === "-end");
+				depth += ( result[ 3 ] === "-start" );
+				depth -= ( result[ 3 ] === "-end" );
 
 				if( depth === 0 ) {
 					return mout.object.merge( section, {
@@ -650,7 +648,16 @@ module.exports = function( grunt ) {
 
 			if ( ! checkFile( src ) ) return;
 
-			bakeFile( src, dest, options.content );
+			var content = mout.object.merge( options.content, {
+				__bake: {
+					filename: src,
+					srcFilename: src,
+					destFilename: dest,
+					timestamp: Date.now()
+				}
+			} );
+
+			bakeFile( src, dest, content );
 		} );
 	} );
 };

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -71,12 +71,12 @@ module.exports = function( grunt ) {
 			return template.replace( options.parsePattern, function( match, inner ) {
 				var processed = processPlaceholder( inner, content );
 
-				if( processed === undefined ) {
+				if ( processed === undefined ) {
 					processed = ( ! options.removeUndefined ? match : "" );
 				}
 
 				return processed;
-			});
+			} );
 		}
 
 		if ( ! options.hasOwnProperty( "process" ) ) {
@@ -189,9 +189,7 @@ module.exports = function( grunt ) {
 		// Returns the filename from a file path
 
 		function filename( path ) {
-			var segments = path.split( "/" );
-
-			return segments.pop();
+			return path.split( "/" ).pop();
 		}
 
 		// Parses attribute string.
@@ -480,6 +478,10 @@ module.exports = function( grunt ) {
 				return processContent( value, values );
 			});
 
+			// inject system variables
+			inlineValues.__filename = filePath;
+			inlineValues.__timestamp = Date.now();
+
 			if ( validateIf( inlineValues, values ) ) return "";
 			if ( validateRender( inlineValues ) ) return "";
 			var forEachValues = [];
@@ -494,7 +496,7 @@ module.exports = function( grunt ) {
 			if( !doProcess ) {
 				content = linebreak + includeContent;
 
-			} else if( forEachName && forEachValues.length > 0 ) {
+			} else if ( forEachName && forEachValues.length > 0 ) {
 
 				var fragment = "";
 				var oldValue = values[ forEachName ];

--- a/test/bake_test.js
+++ b/test/bake_test.js
@@ -47,7 +47,8 @@ exports.bake = {
 			"tmp/extra-0-a-team.html": "test/expected/extra/extra-0-a-team.html",
 			"tmp/extra-1-b-team.html": "test/expected/extra/extra-1-b-team.html",
 			"tmp/assign_bake.html": "test/expected/assign_bake.html",
-			"tmp/inline_no_process.html": "test/expected/inline_no_process.html"
+			"tmp/inline_no_process.html": "test/expected/inline_no_process.html",
+			"tmp/default_variables.html": "test/expected/default_variables.html"
 		};
 
 		test.expect( mout.object.size( files ) );

--- a/test/expected/default_variables.html
+++ b/test/expected/default_variables.html
@@ -1,0 +1,4 @@
+<div>
+    test/fixtures/default_variables.html
+    123456789
+</div>

--- a/test/expected/default_variables.html
+++ b/test/expected/default_variables.html
@@ -1,4 +1,6 @@
 <div>
-    test/fixtures/default_variables.html
     123456789
+    test/fixtures/default_variables.html
+    test/fixtures/default_variables.html
+    tmp/default_variables.html
 </div>

--- a/test/fixtures/default_variables.html
+++ b/test/fixtures/default_variables.html
@@ -1,6 +1,8 @@
 <div>
     <!--(bake-start)-->
-    {{ __filename }}
-    {{ __timestamp }}
+    {{ __bake.timestamp }}
+    {{ __bake.filename }}
+    {{ __bake.srcFilename }}
+    {{ __bake.destFilename }}
     <!--(bake-end)-->
 </div>

--- a/test/fixtures/default_variables.html
+++ b/test/fixtures/default_variables.html
@@ -1,0 +1,6 @@
+<div>
+    <!--(bake-start)-->
+    {{ __filename }}
+    {{ __timestamp }}
+    <!--(bake-end)-->
+</div>


### PR DESCRIPTION
This is first proposed by @nabto in #92 

**TL;DR** The idea is that every bake task has fixed permanent variables that are filled by the system. The way node has `__dirname` for instance. 

Currently a little bit of a work in progress. I haven't nailed down the exact variables that are reasonable. For now we have `__filename` and `__timestamp`. That is a little misleading already because `__filename` is really `__filepath`.

This is a in-progress branch. I just wanted to keep it separate from master so @david-zacharias can have a look at it and give me his opinion (since you built most of the features lately)

Some TODOs:
- cleaner more extensive tests
- possibly broader/different set of permanent variables
- maybe cleaner implementation, though I'm not sure how I could make it any shorter 😉 
- naming convention. I used double underscore prefix. we could also create a `__bake` object and hook them onto that such as `__bake.filename` etc. 
