### PR TITLE
Loop over objects with key and value

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
 	],
 	"main": "Gruntfile.js",
 	"engines": {
-		"node": ">= 0.10.0"
+		"node": ">= 0.11.0"
 	},
 	"scripts": {
 		"test": "grunt test"
 	},
 	"dependencies": {
-		"mout": "~0.11.1"
+		"mout": "~1.0.0"
 	},
 	"devDependencies": {
 		"grunt-contrib-jshint": "~1.0.0",

--- a/test/expected/foreach_bake.html
+++ b/test/expected/foreach_bake.html
@@ -14,5 +14,10 @@
 			<li>baz</li>
 			<li>superman</li>
 		</ul>
+
+		<ul>
+			<li>name - John Dough</li>
+			<li>place - Some place</li>
+		</ul>
 	</body>
 </html>

--- a/test/fixtures/content.json
+++ b/test/fixtures/content.json
@@ -11,6 +11,10 @@
 			"baz",
 			"superman"
 		],
+		"object": {
+			"name": "John Dough",
+			"place": "Some place"
+		},
 		"empty": []
 	},
 

--- a/test/fixtures/foreach_bake.html
+++ b/test/fixtures/foreach_bake.html
@@ -9,5 +9,11 @@
 		<ul>
 			<!--(bake includes/li.html _foreach="value:items")-->
 		</ul>
+
+		<ul>
+			<!--(bake-start  _foreach="object as key => value")-->
+			<li>{{ key }} - {{ value }}</li>
+			<!--(bake-end)-->
+		</ul>
 	</body>
 </html>


### PR DESCRIPTION
Adds initial implementation to loop over objects as discussed in #97 

This isn't very clean at all. I've tried to squeeze it into the current `validateForEach` implementation. So essentially it detects the new syntax: `object as key => value` and then returns out of the function early and returns an object instead of a name. Which then causes the `foreachName` variable to not be a string and therefore super misleading. 

Why did I do this in the first place then? Well, I just wanted to get it in and see what it entails to get that working. I'm also thinking we have reached the point at which, just maybe, it shouldn't be all one file. All the validators could be broken out into different files, I believe. At a quick glance they seem to be very autonomous functions that don't depend on any state values or anything. 

Any thoughts?? @david-zacharias 

PS: I've updated node dependency to `0.11.0` since  that is the lowest we are testing. I'd love to bring it to `4.0.0`. I have no idea how wide spread that is. But it sure would make it nice to use things like `let` in the code base. 
