### PR TITLE
Extends parsing for inline variables

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -253,6 +253,12 @@ module.exports = function(grunt) {
 								author: "Stephen King",
 								title: "The Dark Tower"
 							}
+						},
+						shared: {
+							title: "Title",
+							info: {
+								author: "Test Author"
+							}
 						}
 					}
 				},

--- a/README.md
+++ b/README.md
@@ -213,6 +213,17 @@ Default value: `true`
 Set to `false`, placeholders that could not be resolved (= no matching key in `content`) will be kept untouched in the output.
 
 
+#### options.variableParsePattern
+Type: `Regex`
+Default value: `/\{\{!\s*([^\}]+)\s*\}\}/`
+
+This regex is used to parse the variable specified inline with the bake task. Any inline attribute that
+is not preficed with an unerscore such as `_if` and `_section` is considered a variable and is passed to
+the bake include. For more detail check out the section on [Inline Attributes](#inline-attributes).
+However, if you want to pass not a value but a reference to an different object you can do so by writing
+the inline value as `variable="{{!foo.bar}}"`. Mind the exclamation mark. Assuming `bar` is an object
+as well, this will give you a reference to bar instead of the string.
+
 ### Usage Examples
 
 #### Simple bake
@@ -756,6 +767,7 @@ watch: {
 
 ## Changelog
 
+* `1.9.0`    __1-2-2018__     Adds variableParsePattern for inline variables.
 * `1.8.0`    __4-20-2016__    Adds permanent variables under `__bake`.
 * `1.7.2`    __4-20-2016__    Resolves recursion issues in _process and _assign.
 * `1.7.1`    __4-8-2016__     Fix for issue with _process.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "grunt-bake",
 	"description": "Bake external includes into files to create static pages with no server-side compilation time",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"homepage": "https://github.com/MathiasPaumgarten/grunt-bake",
 	"author": {
 		"name": "Mathias Paumgarten",

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -27,7 +27,7 @@ module.exports = function( grunt ) {
 			basePath: "",
 			transforms: {},
 			parsePattern: /\{\{\s*([^\}]+)\s*\}\}/g,
-			rawParsePattern: /\{\{!\s*([^\}]+)\s*\}\}/,
+			variableParsePattern: /\{\{!\s*([^\}]+)\s*\}\}/,
 			removeUndefined: true
 		} );
 
@@ -478,8 +478,8 @@ module.exports = function( grunt ) {
 
 			// resolve placeholders within inline values so these can be used in subsequent grunt-tags (see #67)
 			inlineValues = mout.object.map( inlineValues, function( value ) {
-				if ( options.rawParsePattern.test( value ) ) {
-					return mout.object.get( parentValues, options.rawParsePattern.exec( value )[ 1 ] );
+				if ( options.variableParsePattern.test( value ) ) {
+					return mout.object.get( parentValues, options.variableParsePattern.exec( value )[ 1 ] );
 				} else {
 					return processContent( value, parentValues );
 				}

--- a/test/expected/section_bake.html
+++ b/test/expected/section_bake.html
@@ -7,5 +7,9 @@
 		<span>The Dark Tower</span>
 
 		<span>Home</span>
+
+		<span>Home</span>
+		<span>Title</span>
+		<span>Test Author</span>
 	</body>
 </html>

--- a/test/fixtures/section_bake.html
+++ b/test/fixtures/section_bake.html
@@ -9,5 +9,11 @@
 		<!--(bake-start _section="home")-->
 		<span>{{title}}</span>
 		<!--(bake-end)-->
+
+		<!--(bake-start _section="home" meta="{{!shared}}"")-->
+		<span>{{title}}</span>
+		<span>{{meta.title}}</span>
+		<span>{{meta.info.author}}</span>
+		<!--(bake-end)-->
 	</body>
 </html>


### PR DESCRIPTION
Inline variable now have an additional way of parsing. The regex to do that is provided in `options.variableParsePattern`.

This allows variables to be parse in a way where they result is not stringified but remains the type it is. If the value is an object, or array it will not turn into `[object Object]`. 

Content:
```json
{
  "foo": {
    "bar": {
      "some": "string"
    }
  }
}
```

One can now pass object inline like: 
```html
<!--(bake include/some.html variable="{{! foo.bar }}")-->
```

This means  in the `some.html` one can use syntax like `{{ variable.some }}` and will get `string`. 

Thank you to @hiulit for thinking this through. 